### PR TITLE
Make `Capture` an alias for `Pattern`

### DIFF
--- a/library/luatex/lpeg.lua
+++ b/library/luatex/lpeg.lua
@@ -55,7 +55,7 @@ lpeg = {}
 ---@field match fun(p: Pattern, s: string)
 
 ---
----@class Capture
+---@alias Capture Pattern
 ---@operator add(Capture): Pattern
 ---@operator mul(Capture): Pattern
 ---@operator mul(Pattern): Pattern

--- a/library/luatex/pdf.lua
+++ b/library/luatex/pdf.lua
@@ -144,7 +144,7 @@ function pdf.setmajorversion(n) end
 
 ---
 ---Return major version number of the PDF file format.
----@see pdf.setmajorversion()
+---@see pdf.setmajorversion
 ---@return integer n # Major version number.
 function pdf.getmajorversion() end
 
@@ -157,7 +157,7 @@ function pdf.setminorversion() end
 
 ---
 ---Return minor version number of the PDF file format.
----@see pdf.setminorversion()
+---@see pdf.setminorversion
 ---@return integer n # Minor version number.
 function pdf.getminorversion() end
 


### PR DESCRIPTION
A `Capture` is a `Pattern` and therefor should be an alias for `Pattern`.

Regarding lua-language-server it might be helpful to set `Lua.hover.expandAlias` to `false` in the configuration file.
For example the tooltip for `lpeg.Cc()` will tell you then that the type of the return value is `Capture` but it will be accepted as a `Pattern` (for e.g. other function arguments) too.